### PR TITLE
Upgrade Slot changes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -168,12 +168,12 @@ var app = new Vue({
     methods: {
         addUpgrade: function(upgrade){
             this.card.upgrades.used += upgrade;
-            this.card.upgrades.used = this.card.upgrades.used.split('').sort().join('');
+            this.card.upgrades.used = this.card.upgrades.used.split('').join('');
             this.renderPreview();
         },
         removeUpgrade: function(upgrade){
             this.card.upgrades.used = this.card.upgrades.used.replace(upgrade, "");
-            this.card.upgrades.used = this.card.upgrades.used.split('').sort().join('');
+            this.card.upgrades.used = this.card.upgrades.used.split('').join('');
             this.renderPreview();
         },
         renderPreview: function () {

--- a/app/app.js
+++ b/app/app.js
@@ -168,12 +168,11 @@ var app = new Vue({
     methods: {
         addUpgrade: function(upgrade){
             this.card.upgrades.used += upgrade;
-            this.card.upgrades.used = this.card.upgrades.used.split('').join('');
             this.renderPreview();
         },
         removeUpgrade: function(upgrade){
-            this.card.upgrades.used = this.card.upgrades.used.replace(upgrade, "");
-            this.card.upgrades.used = this.card.upgrades.used.split('').join('');
+			var pos = this.card.upgrades.used.lastIndexOf(upgrade);
+            this.card.upgrades.used = this.card.upgrades.used.substring(0,pos) + this.card.upgrades.used.substring(pos+1)
             this.renderPreview();
         },
         renderPreview: function () {


### PR DESCRIPTION
Removed sorting on Upgrade slots so that the user can determine the upgrade slot order. Originally intended to automatically sort Upgrade slots into the order they appear on official X-wing cards. However, there is no standard order for upgrade slots: For example, the YT-1300 has the missile slot before crew slots but the Firespray has crew slots before missile slots.